### PR TITLE
fix: use HitRecord instance as a reference

### DIFF
--- a/BoundfoxStudios.RayTracing.Core/HittableList.cs
+++ b/BoundfoxStudios.RayTracing.Core/HittableList.cs
@@ -7,19 +7,20 @@ namespace BoundfoxStudios.RayTracing.Core
   {
     private readonly IList<IHittable> _objects = new List<IHittable>();
     
-    public bool Hit(Ray ray, double tMin, double tMax, out HitRecord hit)
+    public bool Hit(Ray ray, double tMin, double tMax, ref HitRecord rec)
     {
-      hit = default;
+      HitRecord tempRec = default;
       
       var hitAnything = false;
       var closestSoFar = tMax;
 
       foreach (var @object in _objects)
       {
-        if (@object.Hit(ray, tMin, closestSoFar, out hit))
+        if (@object.Hit(ray, tMin, closestSoFar, ref tempRec))
         {
           hitAnything = true;
-          closestSoFar = hit.T;
+          closestSoFar = tempRec.T;
+          rec = tempRec;
         }
       }
 

--- a/BoundfoxStudios.RayTracing.Core/Models/Hittable.cs
+++ b/BoundfoxStudios.RayTracing.Core/Models/Hittable.cs
@@ -2,6 +2,6 @@ namespace BoundfoxStudios.RayTracing.Core.Models
 {
   public interface IHittable
   {
-    bool Hit(Ray ray, double tMin, double tMax, out HitRecord hit);
+    bool Hit(Ray ray, double tMin, double tMax, ref HitRecord rec);
   }
 }

--- a/BoundfoxStudios.RayTracing.Core/Models/Sphere.cs
+++ b/BoundfoxStudios.RayTracing.Core/Models/Sphere.cs
@@ -13,15 +13,13 @@ namespace BoundfoxStudios.RayTracing.Core.Models
       Radius = radius;
     }
     
-    public bool Hit(Ray ray, double tMin, double tMax, out HitRecord hit)
+    public bool Hit(Ray ray, double tMin, double tMax, ref HitRecord rec)
     {
       var oc = ray.Origin - Center;
       var a = ray.Direction.LengthSquared;
       var halfB = Vector3.Dot(oc, ray.Direction);
       var c = oc.LengthSquared - Radius * Radius;
       var discriminant = halfB * halfB - a * c;
-
-      hit = default;
 
       if (discriminant > 0)
       {
@@ -31,11 +29,11 @@ namespace BoundfoxStudios.RayTracing.Core.Models
 
         if (temp < tMax && temp > tMin)
         {
-          hit.T = temp;
-          hit.Point = ray.At(hit.T);
+          rec.T = temp;
+          rec.Point = ray.At(rec.T);
           
-          var outwardNormal = (hit.Point - Center) / Radius;
-          hit.SetFaceNormal(ray, outwardNormal);
+          var outwardNormal = (rec.Point - Center) / Radius;
+          rec.SetFaceNormal(ray, outwardNormal);
           return true;
         }
 
@@ -43,11 +41,11 @@ namespace BoundfoxStudios.RayTracing.Core.Models
         
         if (temp < tMax && temp > tMin)
         {
-          hit.T = temp;
-          hit.Point = ray.At(hit.T);
+          rec.T = temp;
+          rec.Point = ray.At(rec.T);
           
-          var outwardNormal = (hit.Point - Center) / Radius;
-          hit.SetFaceNormal(ray, outwardNormal);
+          var outwardNormal = (rec.Point - Center) / Radius;
+          rec.SetFaceNormal(ray, outwardNormal);
           return true;
         }
       }

--- a/BoundfoxStudios.RayTracing.Core/Ray.cs
+++ b/BoundfoxStudios.RayTracing.Core/Ray.cs
@@ -17,9 +17,10 @@ namespace BoundfoxStudios.RayTracing.Core
 
     public Vector3 Color(IHittable world)
     {
-      if (world.Hit(this, 0, double.PositiveInfinity, out var hit))
+      HitRecord rec = default;
+      if (world.Hit(this, 0, double.PositiveInfinity, ref rec))
       {
-        return 0.5d * (hit.Normal + new Vector3(1, 1, 1));
+        return 0.5d * (rec.Normal + new Vector3(1, 1, 1));
       }
 
       var direction = Direction.UnitVector;


### PR DESCRIPTION
The HitRecord instance should be used as a reference in the Hit methods.
I don't know if this is totally correct with modern C# (cause I'm no C# pro 🤣)